### PR TITLE
Player char - adjustments to script for 'standardProjectile'

### DIFF
--- a/playerChar/playerProjectile/standardProjectile.gd
+++ b/playerChar/playerProjectile/standardProjectile.gd
@@ -6,14 +6,22 @@ extends KinematicBody2D
 # var b = "text"
 var projSpeed = 500
 var projVelocity = Vector2.ZERO
+var angleThreshold = PI / 2
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	pass # Replace with function body.
 
-func shootProjectile(startPos, directionVector):
+func shootProjectile(startPos, directionVector, shooterVelocity):
 	position = startPos
-	projVelocity = directionVector * projSpeed
+	
+	var angleBetweenShotandShooter = abs(directionVector.angle_to(shooterVelocity))
+	var additionalSpeed = 0
+	if (angleBetweenShotandShooter < angleThreshold):
+		additionalSpeed = directionVector.dot(shooterVelocity)
+	
+	var finalSpeed = projSpeed + additionalSpeed
+	projVelocity = directionVector * finalSpeed
 	rotation = directionVector.angle()
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/playerChar/playerProjectile/standardProjectile.gd
+++ b/playerChar/playerProjectile/standardProjectile.gd
@@ -4,12 +4,17 @@ extends KinematicBody2D
 # Declare member variables here. Examples:
 # var a = 2
 # var b = "text"
+var projSpeed = 500
 var projVelocity = Vector2.ZERO
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	pass # Replace with function body.
 
+func shootProjectile(startPos, directionVector):
+	position = startPos
+	projVelocity = directionVector * projSpeed
+	rotation = directionVector.angle()
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _physics_process(delta):

--- a/playerChar/playerProjectile/standardProjectile.tscn
+++ b/playerChar/playerProjectile/standardProjectile.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://playerChar/playerProjectile/arrow_facing_right.png" type="Texture" id=1]
-[ext_resource path="res://playerChar/playerProjectile/playerProjectile.gd" type="Script" id=2]
+[ext_resource path="res://playerChar/playerProjectile/standardProjectile.gd" type="Script" id=2]
 
 [sub_resource type="CapsuleShape2D" id=1]
 radius = 4.23577

--- a/playerChar/playerProjectile/standardProjectile.tscn
+++ b/playerChar/playerProjectile/standardProjectile.tscn
@@ -8,6 +8,7 @@ radius = 4.23577
 height = 10.3019
 
 [node name="playerProjectile" type="KinematicBody2D"]
+collision_mask = 0
 script = ExtResource( 2 )
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/testPlayerControls.gd
+++ b/testPlayerControls.gd
@@ -11,11 +11,10 @@ func _input(event):
 		var gunProjectile = gunProjectileScene.instance()
 		add_child(gunProjectile)
 		
-		gunProjectile.position = $playerChar.position
-		var projectileDirection = $playerChar.position.direction_to(get_global_mouse_position())
-		var projectileSpeed = 200
-		gunProjectile.projVelocity = (projectileDirection * projectileSpeed)
-		gunProjectile.rotation = projectileDirection.angle()
+		gunProjectile.shootProjectile(
+			$playerChar.position,	# Where the projectile starts
+			$playerChar.position.direction_to(get_global_mouse_position())	# Where the projectile goes to.
+		)
 
 # Called when the node enters the scene tree for the first time.
 func _ready():

--- a/testPlayerControls.gd
+++ b/testPlayerControls.gd
@@ -12,8 +12,9 @@ func _input(event):
 		add_child(gunProjectile)
 		
 		gunProjectile.shootProjectile(
-			$playerChar.position,	# Where the projectile starts
-			$playerChar.position.direction_to(get_global_mouse_position())	# Where the projectile goes to.
+			$playerChar.position,
+			$playerChar.position.direction_to(get_global_mouse_position()),
+			$playerChar.currentVelocity
 		)
 
 # Called when the node enters the scene tree for the first time.

--- a/testPlayerControls.tscn
+++ b/testPlayerControls.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://playerChar/playerChar.tscn" type="PackedScene" id=1]
-[ext_resource path="res://playerChar/playerProjectile/playerProjectile.tscn" type="PackedScene" id=2]
+[ext_resource path="res://playerChar/playerProjectile/standardProjectile.tscn" type="PackedScene" id=2]
 [ext_resource path="res://playerChar/playerGunAim/gunCrosshairs.tscn" type="PackedScene" id=3]
 [ext_resource path="res://testPlayerControls.gd" type="Script" id=4]
 


### PR DESCRIPTION
Some adjustments to the code, such as allowing the player's velocity to influence the velocity of the player's fired projectiles.

Also made it so the player's projectiles can't collide with each other, or with anything, for now.